### PR TITLE
Enlarge your form

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -5,6 +5,10 @@ html, body {
   padding: 0;
 }
 
+form {
+  height: 100%;
+}
+
 textarea {
   font: 1.1em Monaco, Menlo, 'Ubuntu Mono', Inconsolata, Consolas, source-code-pro, "Deja Vu Sans Mono", "Droid Sans Mono", "Andale Mono", monospace;
   width: 100%;


### PR DESCRIPTION
Fix the height 100% of the form element. Works on Firefox 18 and Chromium 22.
