### PR TITLE
Add a link to create a new page if it doesn’t exist

### DIFF
--- a/lib/routes.php
+++ b/lib/routes.php
@@ -16,7 +16,7 @@ if ($representation != '') {
 
   if (!$page_exists) {
     header('HTTP/1.0 404 Not Found');
-    die("404 Not Found: $page->name");
+    die("Page not found: <a href=".EDITH_URI."/".$page->name.">Create me!</a>");
   }
 
   if (!in_array($representation, $REPRESENTATIONS)) {


### PR DESCRIPTION
It’s now easy to create a link to a new page in an existing page and follow links to create the page.
