### PR TITLE
Remove the default table cells alignment

### DIFF
--- a/public/html.css
+++ b/public/html.css
@@ -98,7 +98,6 @@ tr:nth-child(2n) {
 th, td {
   border: 1px solid #ddd;
   padding: .6em;
-  text-align: left;
 }
 
 /* Links */


### PR DESCRIPTION
It allows to use the table cells alignment from the Markdown Extra syntax.
